### PR TITLE
Timeout on Clipboard Notification on Bug report

### DIFF
--- a/projects/demo/src/app/components/bug-report/bug-report.component.ts
+++ b/projects/demo/src/app/components/bug-report/bug-report.component.ts
@@ -75,7 +75,9 @@ export class BugReportComponent implements OnInit {
 
   copy() {
     this.cb.copy(this.reportStr);
-    this.toaster.open('copied to clipboard!');
+    this.toaster.open('copied to clipboard!', "Dismiss", {
+      duration: 5000
+    });
   }
 
   download() {

--- a/projects/demo/src/app/components/bug-report/bug-report.component.ts
+++ b/projects/demo/src/app/components/bug-report/bug-report.component.ts
@@ -75,7 +75,7 @@ export class BugReportComponent implements OnInit {
 
   copy() {
     this.cb.copy(this.reportStr);
-    this.toaster.open('copied to clipboard!', '(dismiss)', {
+    this.toaster.open('copied to clipboard!', 'dismiss', {
       duration: 5000
     });
   }

--- a/projects/demo/src/app/components/bug-report/bug-report.component.ts
+++ b/projects/demo/src/app/components/bug-report/bug-report.component.ts
@@ -75,7 +75,7 @@ export class BugReportComponent implements OnInit {
 
   copy() {
     this.cb.copy(this.reportStr);
-    this.toaster.open('copied to clipboard!', "Dismiss", {
+    this.toaster.open('copied to clipboard!', '(dismiss)', {
       duration: 5000
     });
   }


### PR DESCRIPTION
There was no time-out set so the toaster notification just sat there forever. Added a 5 second timeout and a button to dismiss it early.